### PR TITLE
refactor: telemetry config tweaks for CMO support

### DIFF
--- a/controllers/manifests/base/prometheusrule.yaml
+++ b/controllers/manifests/base/prometheusrule.yaml
@@ -7,23 +7,23 @@ spec:
   - name: telemetry.rules
     interval: 60s
     rules:
-    - record: ogx:api_info
+    - record: ogx:api_info:max
       labels:
         api: inference
       expr: clamp_max(sum(ogx_requests_total{api="inference"}) or vector(0), 1)
-    - record: ogx:api_info
+    - record: ogx:api_info:max
       labels:
         api: vector_io
       expr: clamp_max(sum(ogx_requests_total{api="vector_io"}) or vector(0), 1)
-    - record: ogx:api_info
+    - record: ogx:api_info:max
       labels:
         api: responses
       expr: clamp_max(sum(ogx_requests_total{api="responses"}) or vector(0), 1)
-    - record: ogx:api_info
+    - record: ogx:api_info:max
       labels:
         api: rag
       expr: clamp_max(sum(ogx_vector_io_documents_retrieved_total) or vector(0), 1)
-    - record: ogx:api_info
+    - record: ogx:api_info:max
       labels:
         api: agentic
       expr: clamp_max(sum(ogx_responses_agentic_calls_total) or vector(0), 1)

--- a/controllers/manifests/base/service.yaml
+++ b/controllers/manifests/base/service.yaml
@@ -10,3 +10,7 @@ spec:
   ports:
   - name: http
     protocol: TCP
+  - name: metrics
+    port: 9464
+    targetPort: 9464
+    protocol: TCP

--- a/controllers/testing_support_test.go
+++ b/controllers/testing_support_test.go
@@ -299,19 +299,35 @@ func AssertPVCHasSize(t *testing.T, pvc *corev1.PersistentVolumeClaim, expectedS
 
 func AssertServicePortMatches(t *testing.T, service *corev1.Service, expectedPort corev1.ServicePort) {
 	t.Helper()
-	require.Len(t, service.Spec.Ports, 1, "Service should have exactly one port")
-	require.Equal(t, expectedPort, service.Spec.Ports[0], "Service port should match expected")
+	require.GreaterOrEqual(t, len(service.Spec.Ports), 1, "Service should have at least one port")
+	var found bool
+	for _, p := range service.Spec.Ports {
+		if p.Name == expectedPort.Name {
+			require.Equal(t, expectedPort, p, "Service port should match expected")
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Service should contain port named %q", expectedPort.Name)
 }
 
 func AssertServiceAndDeploymentPortsAlign(t *testing.T, service *corev1.Service, deployment *appsv1.Deployment) {
 	t.Helper()
-	require.Len(t, service.Spec.Ports, 1, "Service should have exactly one port")
+	require.NotEmpty(t, service.Spec.Ports, "Service should have at least one port")
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1, "Deployment should have exactly one container")
-	require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].Ports, "Container should have at least one port")
+	containerPorts := deployment.Spec.Template.Spec.Containers[0].Ports
+	require.NotEmpty(t, containerPorts, "Container should have at least one port")
 
-	serviceTargetPort := service.Spec.Ports[0].TargetPort.IntVal
-	containerPort := deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort
-	require.Equal(t, serviceTargetPort, containerPort, "Service target port should match deployment container port")
+	for _, sp := range service.Spec.Ports {
+		var matched bool
+		for _, cp := range containerPorts {
+			if sp.TargetPort.IntVal == cp.ContainerPort {
+				matched = true
+				break
+			}
+		}
+		require.True(t, matched, "Service target port %d should match a deployment container port", sp.TargetPort.IntVal)
+	}
 }
 
 func AssertServiceSelectorMatches(t *testing.T, service *corev1.Service, expectedSelector map[string]string) {

--- a/pkg/deploy/kustomizer.go
+++ b/pkg/deploy/kustomizer.go
@@ -255,6 +255,12 @@ func applyPlugins(resMap *resmap.ResMap, ownerInstance *ogxiov1beta1.OGXServer) 
 		}
 	}
 
+	if isMonitoringDisabledForDeploy(ownerInstance) {
+		if err := removeServiceMetricsPort(*resMap); err != nil {
+			return fmt.Errorf("failed to remove metrics port from Service: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -318,6 +324,60 @@ func removeDeploymentReplicas(resMap resmap.ResMap) error {
 	return nil
 }
 
+func isMonitoringDisabledForDeploy(instance *ogxiov1beta1.OGXServer) bool {
+	return instance.Spec.Monitoring != nil && instance.Spec.Monitoring.Enabled != nil && !*instance.Spec.Monitoring.Enabled
+}
+
+func filterOutMetricsPort(ports []any) []any {
+	var filtered []any
+	for _, p := range ports {
+		port, ok := p.(map[string]any)
+		if !ok {
+			filtered = append(filtered, p)
+			continue
+		}
+		if port["name"] == "metrics" {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
+}
+
+// removeServiceMetricsPort strips the metrics port from the Service when monitoring
+// is disabled. The base service.yaml includes the metrics port by default; this
+// function removes it so the Service only exposes the API port.
+func removeServiceMetricsPort(resMap resmap.ResMap) error {
+	for _, res := range resMap.Resources() {
+		if res.GetKind() != "Service" {
+			continue
+		}
+
+		data, err := parseResourceYAML(res)
+		if err != nil {
+			return err
+		}
+
+		spec, ok := data["spec"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		ports, ok := spec["ports"].([]any)
+		if !ok || len(ports) < 2 {
+			continue
+		}
+
+		spec["ports"] = filterOutMetricsPort(ports)
+
+		if err := updateResourceFromData(res, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // getFieldMappings returns essential field mappings for kustomize transformation.
 func getFieldMappings(ownerInstance *ogxiov1beta1.OGXServer) []plugins.FieldMapping {
 	instanceName := ownerInstance.GetName()
@@ -328,6 +388,27 @@ func getFieldMappings(ownerInstance *ogxiov1beta1.OGXServer) []plugins.FieldMapp
 	instanceLabelPath := "/app.kubernetes.io~1instance"
 
 	mappings := buildFieldMappings(instanceName, instanceNamespace, serviceAccountName, servicePort, storageSize, instanceLabelPath, GetEffectiveReplicas(ownerInstance))
+
+	// When monitoring is enabled and the user overrides the metrics port,
+	// update the Service's second port entry (defined in base/service.yaml).
+	monitoring := ownerInstance.Spec.Monitoring
+	if monitoring == nil || monitoring.Enabled == nil || *monitoring.Enabled {
+		if monitoring != nil && monitoring.MetricsPort != nil {
+			metricsPort := *monitoring.MetricsPort
+			mappings = append(mappings,
+				plugins.FieldMapping{
+					SourceValue: metricsPort,
+					TargetField: "/spec/ports/1/port",
+					TargetKind:  "Service",
+				},
+				plugins.FieldMapping{
+					SourceValue: metricsPort,
+					TargetField: "/spec/ports/1/targetPort",
+					TargetKind:  "Service",
+				},
+			)
+		}
+	}
 
 	// When persistent storage is configured, use Recreate strategy to avoid
 	// RWO PVC multi-attach deadlock during rolling updates

--- a/pkg/deploy/kustomizer_test.go
+++ b/pkg/deploy/kustomizer_test.go
@@ -193,7 +193,7 @@ spec:
   - name: telemetry.rules
     interval: 60s
     rules:
-    - record: ogx:api_info
+    - record: ogx:api_info:max
       labels:
         api: inference
       expr: clamp_max(ogx_requests_total{api="inference"}, 1)


### PR DESCRIPTION
Changes were made during practical testing on an OpenShift 4.21 cluster to allow Prometheus to successfully scrape various metrics from the `/metrics` endpoint for OGX server. Supports CMO PR: (placeholder)

Closes RHAIENG-5163